### PR TITLE
Add model caching in Google Drive for Google Colab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 samples/
 
 **.*ipynb
+
+# Google Drive model cache
+/content/drive/MyDrive/model_cache/


### PR DESCRIPTION
Implement model caching in Google Drive to avoid redownloading in each new Google Colab session.

* **batch_app.py**
  - Import `drive` from `google.colab` to handle Google Drive operations.
  - Add a function `load_or_download_model` to check for cached models in Google Drive and download if not present.
  - Modify the `Binoculars` class initialization to use the `load_or_download_model` function for model loading.
  - Update the argument parsing to include a `cache_dir` argument for specifying the Google Drive cache directory.
  - Mount Google Drive in the main block.

* **binoculars/detector.py**
  - Add a function `load_or_download_model` to check for cached models in Google Drive and download if not present.
  - Modify the `Binoculars` class to use the `load_or_download_model` function for model loading.
  - Update the `Binoculars` class initialization to include a `cache_dir` parameter.

* **.gitignore**
  - Add an entry to exclude cached model files in Google Drive.

