### PR TITLE
Cache models in Google Drive

### DIFF
--- a/batch_app.py
+++ b/batch_app.py
@@ -430,12 +430,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--observer", default="tiiuae/falcon-7b", help="Observer model name or path")
     parser.add_argument("--performer", default="tiiuae/falcon-7b-instruct", help="Performer model name or path")
+    parser.add_argument("--cache_dir", default="/content/drive/MyDrive/model_cache", help="Directory to cache models in Google Drive")
     args = parser.parse_args()
 
     try:
         bino = Binoculars(
             observer_name_or_path=args.observer,
-            performer_name_or_path=args.performer
+            performer_name_or_path=args.performer,
+            cache_dir=args.cache_dir
         )
     except Exception as e:
         raise SystemExit(f"Failed to initialize Binoculars: {e}")

--- a/binoculars/detector.py
+++ b/binoculars/detector.py
@@ -43,6 +43,7 @@ class Binoculars(object):
                  use_bfloat16: bool = True,
                  max_token_observed: int = 512,
                  mode: str = "low-fpr",
+                 cache_dir: str = None,
                  ) -> None:
         """
         Initializes the Binoculars class with the given parameters.
@@ -53,6 +54,7 @@ class Binoculars(object):
             use_bfloat16 (bool): Whether to use bfloat16 precision.
             max_token_observed (int): The maximum number of tokens to observe.
             mode (str): The mode to use for detection ("low-fpr" or "accuracy").
+            cache_dir (str): The directory to cache models in Google Drive.
         """
         assert_tokenizer_consistency(observer_name_or_path, performer_name_or_path)
 
@@ -62,19 +64,21 @@ class Binoculars(object):
                                                                    trust_remote_code=True,
                                                                    torch_dtype=torch.bfloat16 if use_bfloat16
                                                                    else torch.float32,
-                                                                   token=huggingface_config["TOKEN"]
+                                                                   token=huggingface_config["TOKEN"],
+                                                                   cache_dir=cache_dir
                                                                    )
         self.performer_model = AutoModelForCausalLM.from_pretrained(performer_name_or_path,
                                                                     device_map={"": DEVICE_2},
                                                                     trust_remote_code=True,
                                                                     torch_dtype=torch.bfloat16 if use_bfloat16
                                                                     else torch.float32,
-                                                                    token=huggingface_config["TOKEN"]
+                                                                    token=huggingface_config["TOKEN"],
+                                                                    cache_dir=cache_dir
                                                                     )
         self.observer_model.eval()
         self.performer_model.eval()
 
-        self.tokenizer = AutoTokenizer.from_pretrained(observer_name_or_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(observer_name_or_path, cache_dir=cache_dir)
         if not self.tokenizer.pad_token:
             self.tokenizer.pad_token = self.tokenizer.eos_token
         self.max_token_observed = max_token_observed


### PR DESCRIPTION
Add caching mechanism for models in Google Drive to avoid redownloading in each new Google Colab session.

* **batch_app.py**
  - Add `--cache_dir` argument to specify the directory to cache models in Google Drive.
  - Pass `cache_dir` argument to `Binoculars` class during initialization.

* **binoculars/detector.py**
  - Add `cache_dir` parameter to `Binoculars` class constructor.
  - Pass `cache_dir` to `from_pretrained` method for observer and performer models.
  - Pass `cache_dir` to `AutoTokenizer.from_pretrained` method.

